### PR TITLE
add helper manifest_path

### DIFF
--- a/lib/middleman-webpacker/helpers.rb
+++ b/lib/middleman-webpacker/helpers.rb
@@ -19,7 +19,7 @@ module MiddlemanWebpacker
       asset_path(Manifest.lookup(name), **options)
     end
 
-    def manifest_path(name)
+    def manifest_resource_path(name)
       Manifest.lookup(name)
     end
 

--- a/lib/middleman-webpacker/helpers.rb
+++ b/lib/middleman-webpacker/helpers.rb
@@ -19,6 +19,10 @@ module MiddlemanWebpacker
       asset_path(Manifest.lookup(name), **options)
     end
 
+    def manifest_path(name)
+      Manifest.lookup(name)
+    end
+
     private
 
     def extension_options

--- a/lib/middleman-webpacker/version.rb
+++ b/lib/middleman-webpacker/version.rb
@@ -1,3 +1,3 @@
 module MiddlemanWebpacker
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end


### PR DESCRIPTION
This helper comes in handy when you have to work directly with the files compiled by webpack from middleman.