### PR TITLE
Feature webpack CONSTANTS to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,20 +35,24 @@ Then you need to provide your Webpack configuration inside the `config` folder. 
 
 The extension provides the following configuration options:
 
-`dist_path` (default: 'dist')
+* `development_webpack_cmd`
+(default: './node_modules/webpack/bin/webpack.js --watch -d --progress --color --config config/webpack/development.js')\
+command to run webpack in development mode
 
+* `production_webpack_cmd`
+(default: 'NODE_ENV=production ./node_modules/webpack/bin/webpack.js --bail --config config/webpack/production.js')\
+command to run webpack in production mode
+
+* `dist_path` (default: 'dist')\
 Output directory configured in Webpack.
 
-`stylesheets_base_path` (default: '')
-
+* `stylesheets_base_path` (default: '')\
 Base path where stylesheets will be placed inside dist_path.
 
-`javascripts_base_path` (default: '')
-
+* `javascripts_base_path` (default: '')\
 Base path where javascripts will be placed inside dist_path.
 
-`images_base_path` (default: 'img/')
-
+* `images_base_path` (default: 'img/')\
 Base path where images will be placed inside dist_path.
 
 ### Manifest
@@ -80,7 +84,7 @@ This means that all of these assets need to be covered in your Webpack configura
 
 In order to be able to use the assets compiled by Webpack from the HTML you can use the following helpers:
 * `javascript_pack_tag` which replaces `javascript_include_tag`
-* `stylesheet_pack_tag` which replaces `stylesheet_link_tag` 
+* `stylesheet_pack_tag` which replaces `stylesheet_link_tag`
 * `image_pack_tag` which replaces `image_tag`
 * `asset_pack_path` which replaces `asset_path`
 

--- a/lib/middleman-webpacker/extension.rb
+++ b/lib/middleman-webpacker/extension.rb
@@ -4,11 +4,12 @@ require 'middleman-webpacker/helpers'
 module MiddlemanWebpacker
   class Extension < ::Middleman::Extension
 
-    DEVELOPMENT_WEBPACK_CMD = './node_modules/webpack/bin/webpack.js ' \
-      '--watch -d --progress --color --config config/webpack/development.js'
-    PRODUCTION_WEBPACK_CMD = 'NODE_ENV=production ./node_modules/webpack/bin/webpack.js ' \
-      '--bail -p --config config/webpack/production.js'
-
+    option :development_webpack_cmd, './node_modules/webpack/bin/webpack.js ' \
+      '--watch -d --progress --color --config config/webpack/development.js',
+      'command to run webpack in development mode'
+    option :production_webpack_cmd, 'NODE_ENV=production ./node_modules/webpack/bin/webpack.js ' \
+      '--bail --config config/webpack/production.js',
+      'command to run webpack in production mode'
     option :dist_path, 'dist', 'Output directory configured in Webpack'
     option :stylesheets_base_path, '', 'Base path where stylesheets will be placed inside dist_path'
     option :javascripts_base_path, '', 'Base path where javascripts will be placed inside dist_path'
@@ -31,7 +32,7 @@ module MiddlemanWebpacker
 
       @app.activate :external_pipeline,
         name: :webpack,
-        command: @app.build? ? PRODUCTION_WEBPACK_CMD : DEVELOPMENT_WEBPACK_CMD,
+        command: @app.build? ? options.production_webpack_cmd : options.development_webpack_cmd,
         source: options.dist_path,
         latency: 1
     end

--- a/lib/middleman-webpacker/version.rb
+++ b/lib/middleman-webpacker/version.rb
@@ -1,3 +1,3 @@
 module MiddlemanWebpacker
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end


### PR DESCRIPTION
Changed the webpack CONSTANTS to options and I have removed the `-p` of production by default.

The other options do not remove them because they seem fine by default and can now be easily modified from the same middleman config.rb

Added these options to the readme and I have adjusted the format a bit